### PR TITLE
Ct/fix set error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ perl:
     - "5.14"
     - "5.12"
 services:
-    - redis-server: "2.4"
+    - redis-server
 before_install:
     - "cpanm JSON"
     - "cpanm DateTime"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ perl:
     - "5.14"
     - "5.12"
 services:
-    - redis-server
+    - redis-server: "2.4"
 before_install:
     - "cpanm JSON"
     - "cpanm DateTime"

--- a/Changes
+++ b/Changes
@@ -23,3 +23,6 @@ Revision history for Cache-RedisDB
 
 0.08    08/04/2015
         Fixed tests running on old redis server.
+
+0.09	09/09/2015
+	Better documentation and test fixes for Redis before extended options

--- a/lib/Cache/RedisDB.pm
+++ b/lib/Cache/RedisDB.pm
@@ -13,7 +13,7 @@ Cache::RedisDB - RedisDB based cache system
 
 =head1 VERSION
 
-Version 0.08
+Version 0.09
 
 =head1 DESCRIPTION
 
@@ -26,7 +26,7 @@ extended options in ->set().
 
 =cut
 
-our $VERSION = '0.080_2';
+our $VERSION = '0.09';
 
 =head1 SYNOPSIS
 

--- a/lib/Cache/RedisDB.pm
+++ b/lib/Cache/RedisDB.pm
@@ -26,7 +26,7 @@ extended options in ->set().
 
 =cut
 
-our $VERSION = '0.08';
+our $VERSION = '0.080_1';
 
 =head1 SYNOPSIS
 

--- a/lib/Cache/RedisDB.pm
+++ b/lib/Cache/RedisDB.pm
@@ -26,7 +26,7 @@ extended options in ->set().
 
 =cut
 
-our $VERSION = '0.080_1';
+our $VERSION = '0.080_2';
 
 =head1 SYNOPSIS
 

--- a/t/cache.t
+++ b/t/cache.t
@@ -61,8 +61,8 @@ if (fork) {
              ),
              "Set Hash::Ref"
         );
+        $child->ok(Cache::RedisDB->set("Date", "Time", $now), "Set Date::Time");
     }
-    $child->ok(Cache::RedisDB->set("Date", "Time", $now), "Set Date::Time");
     $child->is_eq(Cache::RedisDB->get("Test", "key1"), "value1", "Got value1 for Test::key1");
     $child->ok($child->is_passing, 'Child is passing, new test to track down concurrency issues');
     die unless $child->is_passing;
@@ -101,10 +101,10 @@ SKIP: {
       },
       "Got hash from the cache"
     );
-}
+    my $now2 = Cache::RedisDB->get("Date", "Time");
+    eq_or_diff [$now->year, $now->month, $now->second, $now->time_zone], \@now_exp, "Got correct Date::Time object from cache";
 
-my $now2 = Cache::RedisDB->get("Date", "Time");
-eq_or_diff [$now->year, $now->month, $now->second, $now->time_zone], \@now_exp, "Got correct Date::Time object from cache";
+}
 
 is(Cache::RedisDB->get("NonExistent", "Key"), undef, "Got undef value for non-existing key");
 

--- a/t/cache.t
+++ b/t/cache.t
@@ -28,7 +28,7 @@ is $cache2, $cache, "Got the same cache object";
 
 my @version = split(/\./, $cache->info->{redis_version});
 
-diag "Redis server version: $cache->info->{redis_version}";
+diag "Redis server version: ". $cache->info->{redis_version};
 
 my $sufficient_version = 1 if (($version[0] >= 2) && ($version[1] >= 6) && 
                                ($version[2] >= 12));

--- a/t/cache.t
+++ b/t/cache.t
@@ -30,7 +30,8 @@ my @version = split(/\./, $cache->info->{redis_version});
 
 diag "Redis server version: ". $cache->info->{redis_version};
 
-my $sufficient_version = 1 if (($version[0] >= 2) && ($version[1] >= 6) && 
+my $sufficient_version = 0;
+$sufficient_version = 1 if (($version[0] >= 2) && ($version[1] >= 6) && 
                                ($version[2] >= 12));
 
 

--- a/t/cache.t
+++ b/t/cache.t
@@ -49,7 +49,7 @@ if (fork) {
     $child->ok(Cache::RedisDB->set_nw("", "Testkey1", "testvalue1"), "Set Testkey1 (no wait version)");
     $child->ok(Cache::RedisDB->set("-", "-", "-- it works! 它的工程！"), "Set dash prefixed string");
     SKIP: {
-         skip 'Redis 2.6.12 or higher', 1 unless $sufficient_version;
+         skip 'Redis 2.6.12 or higher', 2 unless $sufficient_version;
             $child->ok(
               Cache::RedisDB->set(
                   "Hash", "Ref",
@@ -91,7 +91,7 @@ is(Cache::RedisDB->get("Test", "Undef"), undef, "Got undef");
 is(Cache::RedisDB->get("Test", "Empty"), "",    "Got empty string");
 
 SKIP: {
-    skip 'Redis 2.6.12 or higher', 1 unless $sufficient_version;
+    skip 'Redis 2.6.12 or higher', 2 unless $sufficient_version;
     eq_or_diff(
       Cache::RedisDB->get("Hash", "Ref"),
       {

--- a/t/cache.t
+++ b/t/cache.t
@@ -19,6 +19,16 @@ my $cache = Cache::RedisDB->redis;
 plan(skip_all => 'Redis Server Not Found') unless $cache;
 plan(skip_all => "Test requires redis-server at least 1.2") unless $cache->version ge 1.003015;
 
+diag "Redis server version: ". $cache->info->{redis_version};
+
+my @version = split(/\./, $cache->info->{redis_version});
+my $sufficient_version = 0;
+$sufficient_version = 1 if (($version[0] >= 2) && ($version[1] >= 6) && 
+                               ($version[2] >= 12));
+
+
+plan (skip_all => 'Skipping full cache test due to Redis being below 2.6.12')
+    unless $sufficient_version;
 $cache->flushdb;
 
 isa_ok($cache, 'RedisDB', "RedisDB is used for cache");
@@ -26,14 +36,6 @@ can_ok($cache, 'flushall');
 
 my $cache2 = Cache::RedisDB->redis;
 is $cache2, $cache, "Got the same cache object";
-
-my @version = split(/\./, $cache->info->{redis_version});
-
-diag "Redis server version: ". $cache->info->{redis_version};
-
-my $sufficient_version = 0;
-$sufficient_version = 1 if (($version[0] >= 2) && ($version[1] >= 6) && 
-                               ($version[2] >= 12));
 
 
 my $now = DateTime->now;

--- a/t/cache.t
+++ b/t/cache.t
@@ -7,6 +7,7 @@ use DateTime;
 use JSON qw(from_json);
 use RedisServer;
 use Cache::RedisDB;
+use strict;
 
 my $server = RedisServer->start;
 plan(skip_all => "Can't start redis-server") unless $server;

--- a/t/cache.t
+++ b/t/cache.t
@@ -124,14 +124,17 @@ is($cache->get("Test::Num2"), -55, "It is stored as number");
 
 subtest 'JSON' => sub {
     plan tests => 6;
-    my $json_string = '{"should_be_true" : true, "should_be_false" : false}';
-    my $json_obj    = from_json($json_string);
-    ok($json_obj->{should_be_true},   'True is true');
-    ok(!$json_obj->{should_be_false}, 'False is false');
-    ok(Cache::RedisDB->set('Test', 'JSON', $json_obj), 'Stored JSON successfully');
-    ok($json_obj = Cache::RedisDB->get('Test', 'JSON'), 'Retrieved JSON successfully');
-    ok($json_obj->{should_be_true},   'True is true');
-    ok(!$json_obj->{should_be_false}, 'False is false');
+    SKIP: {
+        skip 'Redis 2.6.12 or higher', 6 unless $sufficient_version;
+        my $json_string = '{"should_be_true" : true, "should_be_false" : false}';
+        my $json_obj    = from_json($json_string);
+        ok($json_obj->{should_be_true},   'True is true');
+        ok(!$json_obj->{should_be_false}, 'False is false');
+        ok(Cache::RedisDB->set('Test', 'JSON', $json_obj), 'Stored JSON successfully');
+        ok($json_obj = Cache::RedisDB->get('Test', 'JSON'), 'Retrieved JSON successfully');
+        ok($json_obj->{should_be_true},   'True is true');
+        ok(!$json_obj->{should_be_false}, 'False is false');
+    } 
 };
 
 is(Cache::RedisDB->flushall, 'OK', "Flushed DB");

--- a/t/cache.t
+++ b/t/cache.t
@@ -27,6 +27,9 @@ my $cache2 = Cache::RedisDB->redis;
 is $cache2, $cache, "Got the same cache object";
 
 my @version = split(/\./, $cache->info->{redis_version});
+
+diag "Redis server version: $cache->info->{redis_version}";
+
 my $sufficient_version = 1 if (($version[0] >= 2) && ($version[1] >= 6) && 
                                ($version[2] >= 12));
 


### PR DESCRIPTION
Corrects more tests for Redis 2.4, awaiting final confirmation on cpantesters before releasing 0.09 with full fixes.

Some significant hampering here was caused by the fact that Travis only offers Redis 2.8 afaics and so no good way to automaticlaly test other than handing cpantesters something to chew on.