### PR TITLE
add optional redis() connection parameter

### DIFF
--- a/lib/Cache/RedisDB.pm
+++ b/lib/Cache/RedisDB.pm
@@ -68,12 +68,14 @@ sub redis_connection {
 
 =head2 redis
 
-Returns a singleton L<RedisDB> instance.
+Returns (or sets) a singleton L<RedisDB> instance.
 
 =cut
 
 sub redis {
+    my $connection = $_[-1];
     state $redis;
+    $redis = $connection if defined $connection;
     $redis //= redis_connection();
     return $redis;
 }


### PR DESCRIPTION
Allows for such use cases as Cache::RedisDB->redis($RedisDB_Cluster_instance)

_I didn't see a simpler way of allowing Cache:RedisDB to use RedisDB::Cluster - please correct me if I'm doingItWrong™!_